### PR TITLE
Fix carriage return rendering in Obsidian and Mail applications

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -65,7 +65,7 @@ export default class MailBlockPlugin extends Plugin {
                         "?subject=" + this.encodeToHtml(subjectContent) +
                         (ccContent !== undefined ? "&cc=" + this.encodeToHtml(ccContent) : "") +
                         (bccContent !== undefined ? "&bcc=" + this.encodeToHtml(bccContent) : "") +
-                        (bodyContent.innerText.length !== 0 ? "&body=" + this.encodeToHtml(bodyContent.innerText) : "");
+                        (bodyContent.innerText.length !== 0 ? "&body=" + this.encodeToHtml(bodyContent.innerText.replace(/\n\n/g, '\n')) : "");
                     const mailToButton = rootEl
                         .createEl("div", {cls: "email-block-mailto"})
                         .createEl("a", {href: data, text: "Mailto"});
@@ -85,8 +85,8 @@ export default class MailBlockPlugin extends Plugin {
             yamlString = yamlString.replace("]]", ']]"');
         }
         let extraBody = "";
-        if (yamlString.contains("---")) {
-            let data = yamlString.split("---");
+        if (yamlString.contains("---\n")) {
+            let data = yamlString.split("---\n");
             yamlString = data[0];
             extraBody = data[1];
         }
@@ -186,7 +186,11 @@ export default class MailBlockPlugin extends Plugin {
             bodyContent = this.replaceVariables(bodyContent, variables);
             let lines = bodyContent.split("\n");
             lines.forEach(line => {
-                bodyContentEl.createEl("div", {cls: "email-block-body-line", text: line});
+                const elementType = !line ? "br" : "div";
+                bodyContentEl.createEl(elementType, {
+                    cls: elementType === 'div' ? "email-block-body-line" : undefined,
+                    text: line
+                })
             })
         }
     }


### PR DESCRIPTION
fixed during [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/) event


I tried to fix the render body because it doesn't handle CarriageReturn properly.

this code:
````
```email
to: info@randommail.com
subject: reminder for {{name}}
---
Dear {{name}},

this is not a personal email.

Regards,

FI
```
````

It generates this on Obisdian
<img width="326" alt="image" src="https://github.com/user-attachments/assets/7a31e6b9-686f-46e6-93c9-22942338a2c3" />


and in your favorite email application (like Outlook for instance) this
<img width="689" alt="image" src="https://github.com/user-attachments/assets/d917dba6-7ea0-40b0-a17b-df980ea77111" />

I think this simple fix could make the plugin more usable