### PR TITLE
Add a date field

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ You can customize the view with the following parameters:
 | showmailto | Show the "mailto" link after the mail body.                            | true/false (Default: true)     |          |
 | variables  | A map of placeholder variables.                                        | YAML Object                    |          | 
 | from       | A from field (only for documentation).                                 | String value                   |          | 
+| date       | The date/time the mail was sent (only for documentation).              | String value                   |          | 
 
 1) The body can be appended after the yaml with a "---" separation
 2) No formatting is supported (only new

--- a/main.ts
+++ b/main.ts
@@ -9,6 +9,7 @@ interface MailBlockParameters {
     showmailto: boolean | undefined;
     variables: { [name: string]: string | undefined }
     from: string | undefined;
+    date: string | undefined;
 }
 
 export default class MailBlockPlugin extends Plugin {
@@ -30,6 +31,11 @@ export default class MailBlockPlugin extends Plugin {
             try {
                 const rootEl = el.createEl("div", {cls: "email-block email-block-border"});
 
+                if (parameters.date !== undefined) {
+                    rootEl.createEl("div", {cls: "email-block-info", text: "Date:"});
+                    const dateContent = this.replaceVariables(parameters.date, parameters.variables)
+                    rootEl.createEl("div", {cls: "email-block-info-value", text: dateContent});
+                }
                 let fromContent = undefined;
                 if (parameters.from !== undefined) {
                     rootEl.createEl("div", {cls: "email-block-info", text: "From:"});
@@ -84,7 +90,7 @@ export default class MailBlockPlugin extends Plugin {
             yamlString = yamlString.replace("[[", '"[[');
             yamlString = yamlString.replace("]]", ']]"');
         }
-        let extraBody = "";
+        let extraBody = undefined;
         if (yamlString.contains("---\n")) {
             let data = yamlString.split("---\n");
             yamlString = data[0];


### PR DESCRIPTION
Fixes #19.

I made the date field a string for now that is just displayed as is, because I did not know what the proper input format should be and what the best output format would be. Some plugins let the user configure date/time formats, but since this plugin does not have settings at the moment I thought this would be overkill.

The date field is rendered at the top because it made the most sense to me.

I also initialized `extraBody` to undefined, because it would render an empty body in some cases otherwise.